### PR TITLE
Prevent integer overflow when allocating native_handle_t

### DIFF
--- a/libcutils/native_handle.c
+++ b/libcutils/native_handle.c
@@ -25,11 +25,17 @@
 #include <cutils/log.h>
 #include <cutils/native_handle.h>
 
+static const int kMaxNativeFds = 1024;
+static const int kMaxNativeInts = 1024;
+
 native_handle_t* native_handle_create(int numFds, int numInts)
 {
-    native_handle_t* h = malloc(
-            sizeof(native_handle_t) + sizeof(int)*(numFds+numInts));
+    if (numFds < 0 || numInts < 0 || numFds > kMaxNativeFds || numInts > kMaxNativeInts) {
+        return NULL;
+    }
 
+    size_t mallocSize = sizeof(native_handle_t) + (sizeof(int) * (numFds + numInts));
+    native_handle_t* h = malloc(mallocSize);
     if (h) {
         h->version = sizeof(native_handle_t);
         h->numFds = numFds;


### PR DESCRIPTION
User specified values of numInts and numFds can overflow
and cause malloc to allocate less than we expect, causing
heap corruption in subsequent operations on the allocation.

Bug: 19334482
Change-Id: I43c75f536ea4c08f14ca12ca6288660fd2d1ec55